### PR TITLE
Update dataTables.rowGroup.js

### DIFF
--- a/js/dataTables.rowGroup.js
+++ b/js/dataTables.rowGroup.js
@@ -219,6 +219,10 @@ $.extend( RowGroup.prototype, {
 			var d = this.data();
 			var group = that.s.dataFn( d );
 
+			if ( group === null || group === undefined ) {
+				group = that.c.emptyDataGroup;
+			}
+			
 			if ( last === undefined || group !== last ) {
 				groupedRows.push( [] );
 				last = group;

--- a/js/dataTables.rowGroup.js
+++ b/js/dataTables.rowGroup.js
@@ -212,27 +212,29 @@ $.extend( RowGroup.prototype, {
 			groupedRows[ groupedRows.length - 1 ].push( this.index() );
 		} );
 
-		for ( var i=0, ien=groupedRows.length ; i<ien ; i++ ) {
-			var group = groupedRows[i];
-			var firstRow = dt.row(group[0]);
-			var groupName = this.s.dataFn( firstRow.data() );
-
-			if ( this.c.startRender ) {
-				display = this.c.startRender.call( this, dt.rows(group), groupName );
-				
-				this
-					._rowWrap( display, this.c.startClassName )
-					.insertBefore( firstRow.node() );
-			}
-
-			if ( this.c.endRender ) {
-				display = this.c.endRender.call( this, dt.rows(group), groupName );
-				
-				this
-					._rowWrap( display, this.c.endClassName )
-					.insertAfter( dt.row( group[ group.length-1 ] ).node() );
-			}
-		}
+        if (groupedRows.length != rows[0].length || !this.c.hideIfSame) {
+    		for ( var i=0, ien=groupedRows.length ; i<ien ; i++ ) {
+    			var group = groupedRows[i];
+    			var firstRow = dt.row(group[0]);
+    			var groupName = this.s.dataFn( firstRow.data() );
+    
+    			if ( this.c.startRender ) {
+    				display = this.c.startRender.call( this, dt.rows(group), groupName );
+    				
+    				this
+    					._rowWrap( display, this.c.startClassName )
+    					.insertBefore( firstRow.node() );
+    			}
+    
+    			if ( this.c.endRender ) {
+    				display = this.c.endRender.call( this, dt.rows(group), groupName );
+    				
+    				this
+    					._rowWrap( display, this.c.endClassName )
+    					.insertAfter( dt.row( group[ group.length-1 ] ).node() );
+    			}
+    		}
+        }
 	},
 
 	/**
@@ -304,6 +306,12 @@ RowGroup.defaults = {
 	 * @boolean
 	 */
 	enable: true,
+
+	/**
+	 * Hide if all rows belong to the same group
+	 * @boolean
+	 */
+	hideIfSame: false,
 
 	/**
 	 * Class name to give to the end grouping row

--- a/js/dataTables.rowGroup.js
+++ b/js/dataTables.rowGroup.js
@@ -212,7 +212,7 @@ $.extend( RowGroup.prototype, {
 			groupedRows[ groupedRows.length - 1 ].push( this.index() );
 		} );
 
-        if (groupedRows.length != rows[0].length || !this.c.hideIfSame) {
+        if (groupedRows[0].length != rows[0].length || !this.c.hideIfSame) {
     		for ( var i=0, ien=groupedRows.length ; i<ien ; i++ ) {
     			var group = groupedRows[i];
     			var firstRow = dt.row(group[0]);

--- a/js/dataTables.rowGroup.js
+++ b/js/dataTables.rowGroup.js
@@ -146,20 +146,35 @@ $.extend( RowGroup.prototype, {
 	{
 		var that = this;
 		var dt = this.s.dt;
+		var rows = dt.rows();
+		var groups = [];
 
-		dt.on( 'draw.dtrg', function () {
-			if ( that.c.enable ) {
-				that._draw();
+		rows.every( function () {
+			var d = this.data();
+			var group = that.s.dataFn( d );
+			
+			if ( groups.indexOf(group) == -1 ) {
+				groups.push( group );
 			}
 		} );
+		
+		if (groups.length > 1 || !this.c.hideIfSame) {
+		    
+    		dt.on( 'draw.dtrg', function () {
+    			if ( that.c.enable ) {
+    				that._draw();
+    			}
+    		} );
+    
+    		dt.on( 'column-visibility.dt.dtrg responsive-resize.dt.dtrg', function () {
+    			that._adjustColspan();
+    		} );
+    
+    		dt.on( 'destroy', function () {
+    			dt.off( '.dtrg' );
+    		} );
+		}
 
-		dt.on( 'column-visibility.dt.dtrg responsive-resize.dt.dtrg', function () {
-			that._adjustColspan();
-		} );
-
-		dt.on( 'destroy', function () {
-			dt.off( '.dtrg' );
-		} );
 	},
 
 
@@ -212,29 +227,27 @@ $.extend( RowGroup.prototype, {
 			groupedRows[ groupedRows.length - 1 ].push( this.index() );
 		} );
 
-        if (groupedRows[0].length != rows[0].length || !this.c.hideIfSame) {
-    		for ( var i=0, ien=groupedRows.length ; i<ien ; i++ ) {
-    			var group = groupedRows[i];
-    			var firstRow = dt.row(group[0]);
-    			var groupName = this.s.dataFn( firstRow.data() );
-    
-    			if ( this.c.startRender ) {
-    				display = this.c.startRender.call( this, dt.rows(group), groupName );
-    				
-    				this
-    					._rowWrap( display, this.c.startClassName )
-    					.insertBefore( firstRow.node() );
-    			}
-    
-    			if ( this.c.endRender ) {
-    				display = this.c.endRender.call( this, dt.rows(group), groupName );
-    				
-    				this
-    					._rowWrap( display, this.c.endClassName )
-    					.insertAfter( dt.row( group[ group.length-1 ] ).node() );
-    			}
-    		}
-        }
+		for ( var i=0, ien=groupedRows.length ; i<ien ; i++ ) {
+			var group = groupedRows[i];
+			var firstRow = dt.row(group[0]);
+			var groupName = this.s.dataFn( firstRow.data() );
+
+			if ( this.c.startRender ) {
+				display = this.c.startRender.call( this, dt.rows(group), groupName );
+				
+				this
+					._rowWrap( display, this.c.startClassName )
+					.insertBefore( firstRow.node() );
+			}
+
+			if ( this.c.endRender ) {
+				display = this.c.endRender.call( this, dt.rows(group), groupName );
+				
+				this
+					._rowWrap( display, this.c.endClassName )
+					.insertAfter( dt.row( group[ group.length-1 ] ).node() );
+			}
+		}
 	},
 
 	/**
@@ -404,3 +417,4 @@ $(document).on( 'preInit.dt.dtrg', function (e, settings, json) {
 return RowGroup;
 
 }));
+

--- a/js/dataTables.rowGroup.js
+++ b/js/dataTables.rowGroup.js
@@ -157,8 +157,8 @@ $.extend( RowGroup.prototype, {
 				groups.push( group );
 			}
 		} );
-		
-		if (groups.length > 1 || !this.c.hideIfSame) {
+
+		if (!((groups.length === 1 && this.c.hideIfAllSame) || (groups.length === rows[0].length && this.c.hideIfAllUnique))) {
 		    
     		dt.on( 'draw.dtrg', function () {
     			if ( that.c.enable ) {
@@ -328,7 +328,13 @@ RowGroup.defaults = {
 	 * Hide if all rows belong to the same group
 	 * @boolean
 	 */
-	hideIfSame: false,
+	hideIfAllSame: false,
+
+	/**
+	 * Hide if all rows belong to unique groups
+	 * @boolean
+	 */
+	hideIfAllUnique: false,
 
 	/**
 	 * Class name to give to the end grouping row
@@ -421,4 +427,3 @@ $(document).on( 'preInit.dt.dtrg', function (e, settings, json) {
 return RowGroup;
 
 }));
-


### PR DESCRIPTION
Allan, my first ever pull request for anything -- so my apologies if I don't get it quite right!

At any rate, this change is based on the very last part of this discussion: https://datatables.net/forums/discussion/comment/123641/#Comment_123641

My suggestion was to have an option to hide the row group if all the rows are the same.

I've added an option called "hideIfSame" with a default of false.

Although Github's comparison shows multiple lines changed under the _draw function, the only change was to wrap the loop in an if statement.

Please let me know if you have any questions or if there's anything I can do to help make this better (i.e., convince you to add this feature!).

If you incorporate this, it's available under the same MIT license as the DataTables project.