### PR TITLE
Declaring "that" in _group.

### DIFF
--- a/js/dataTables.rowGroup.js
+++ b/js/dataTables.rowGroup.js
@@ -229,6 +229,7 @@ $.extend( RowGroup.prototype, {
 		var dt = this.s.dt;
 		var group, last;
 		var data = [];
+		var that = this;
 
 		for ( var i=0, ien=rows.length ; i<ien ; i++ ) {
 			var rowIndex = rows[i];


### PR DESCRIPTION
*this contribution is offered under and will be made available under the project's existing license (MIT).*

In Safari on the Mac (at least), group header rows won't render due to `that` not being defined in `_group`.
