### PR TITLE
Support for HTML5 data-* attributes

### DIFF
--- a/js/dataTables.rowGroup.js
+++ b/js/dataTables.rowGroup.js
@@ -239,7 +239,11 @@ $.extend( RowGroup.prototype, {
 			if ( group === null || group === undefined ) {
 				group = that.c.emptyDataGroup;
 			}
-			
+
+			if ( group.display !== undefined ) {
+				group = group.display;
+			}
+
 			if ( last === undefined || group !== last ) {
 				data.push( {
 					dataPoint: group,


### PR DESCRIPTION
When [HTML5 data-* attributes](https://datatables.net/examples/advanced_init/html5-data-attributes.html) are used, `_fnGetObjectDataFn` returns an object like
`Object { display: "Text", "@data-sort": "Sort", "@data-filter": "Filter" }`

This results in always comparing two different objects for equality, and therefore not grouping at all.