### PR TITLE
Adding option on _group to accept custom data source

### DIFF
--- a/js/dataTables.rowGroup.js
+++ b/js/dataTables.rowGroup.js
@@ -245,6 +245,10 @@ $.extend( RowGroup.prototype, {
 			if ( group === null || group === undefined ) {
 				group = that.c.emptyDataGroup;
 			}
+
+			if (typeof group == "object" && group.display !== undefined) {
+				group = group.display;
+			}
 			
 			if ( last === undefined || group !== last ) {
 				data.push( {


### PR DESCRIPTION
When using custom data source the code is not grouping.

Example:
        var dataSet = [
            ['Jose', {
				"display": "one",
				"order": 1
			}],
            ['Maria', {
				"display": "one",
				"order": 1
			}],
            ['Joao', {
				"display": "four",
				"order": 4
			}],
            ['Jose', {
				"display": "seven",
				"order": 7
			}]];

$('#el').DataTable({
	columns: [
		{
			title: "NAME"
		},
               	{
			title: "VALUE",
			render: {
				_: 'display'
			}
                }
	],
	rowGroup: {
		dataSrc:[1]
	}
});

The change described will use the value inside of 'display' to group the items.
Other solution would be transform the object in json so the line 249 wouldn't treat the objects as different values.

thanks,
R.
